### PR TITLE
Allow connections through SSL

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
 (defproject clj-irc "0.0.2-SNAPSHOT"
   :description "clojure irc client based on pircbotx"
-  :dependencies [[org.clojure/clojure   "1.3.0"]
-                 [org.pircbotx/pircbotx "1.7"]])
+  :dependencies [[org.clojure/clojure   "1.8.0"]
+                 [org.pircbotx/pircbotx "1.9"]])


### PR DESCRIPTION
Using the :ssl? true parameter allow to enable SSL connections (using the default SSLSocketFactory).

PircBotX version has been bumped to 1.9 (2.0 introduce major breaking changes).

I've also added the :verbose? parameter (useful to debug non-working client), and removed all reflection warnings :-)
